### PR TITLE
🚀 Release v4.15.0

### DIFF
--- a/.changeset/auto-1759329918.md
+++ b/.changeset/auto-1759329918.md
@@ -1,6 +1,0 @@
----
-"@club-employes/utopia": minor
----
-
-Updates from branch feat/update_token:
-- Design system components updated

--- a/.changeset/auto-1759334663.md
+++ b/.changeset/auto-1759334663.md
@@ -1,6 +1,0 @@
----
-"@club-employes/utopia": minor
----
-
-Updates from branch feat/update_token:
-- Design system components updated

--- a/.changeset/auto-1759335433.md
+++ b/.changeset/auto-1759335433.md
@@ -1,6 +1,0 @@
----
-"@club-employes/utopia": minor
----
-
-Updates from branch feat/update_token:
-- Design system components updated

--- a/.changeset/auto-1759390363.md
+++ b/.changeset/auto-1759390363.md
@@ -1,6 +1,0 @@
----
-"@club-employes/utopia": minor
----
-
-Updates from branch feat/update_token:
-- Design system components updated

--- a/.changeset/auto-1759390609.md
+++ b/.changeset/auto-1759390609.md
@@ -1,6 +1,0 @@
----
-"@club-employes/utopia": minor
----
-
-Updates from branch feat/update_token:
-- Design system components updated

--- a/.changeset/auto-1759391142.md
+++ b/.changeset/auto-1759391142.md
@@ -1,6 +1,0 @@
----
-"@club-employes/utopia": minor
----
-
-Updates from branch feat/update_token:
-- Design system components updated

--- a/.changeset/auto-1759391309.md
+++ b/.changeset/auto-1759391309.md
@@ -2,5 +2,5 @@
 "@club-employes/utopia": minor
 ---
 
-Updates from branch version/v4.14.0:
+Updates from branch version/v4.15.0:
 - Design system components updated

--- a/packages/utopia/CHANGELOG.md
+++ b/packages/utopia/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @club-employes/utopia
 
+## 4.15.0
+
+### Minor Changes
+
+- 46bf837: Updates from branch feat/update_token:
+  - Design system components updated
+- 46bf837: Updates from branch feat/update_token:
+  - Design system components updated
+- 46bf837: Updates from branch feat/update_token:
+  - Design system components updated
+- 46bf837: Updates from branch feat/update_token:
+  - Design system components updated
+- 46bf837: Updates from branch feat/update_token:
+  - Design system components updated
+- f4d5419: Updates from branch version/v4.14.0:
+  - Design system components updated
+- 46bf837: Updates from branch feat/update_token:
+  - Design system components updated
+
 ## 4.14.0
 
 ### Minor Changes

--- a/packages/utopia/package.json
+++ b/packages/utopia/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@club-employes/utopia",
   "description": "🎨 Modern Vue 3 design system with multi-brand theming, design tokens, and 30+ components. Supports Club Employés & Gifteo brands with light/dark modes.",
-  "version": "4.14.0",
+  "version": "4.15.0",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",


### PR DESCRIPTION
Automated version bump to v4.15.0

  **Changes:**
  - Version bumped to 4.15.0
  - Changesets consumed
  - Ready to publish to NPM

  This PR will be auto-merged and published to NPM.