### PR TITLE
🚀 Release v4.21.0

### DIFF
--- a/.changeset/auto-1759419226.md
+++ b/.changeset/auto-1759419226.md
@@ -1,6 +1,0 @@
----
-"@club-employes/utopia": minor
----
-
-Updates from branch fix/workflow-changeset-trigger:
-- Design system components updated

--- a/.changeset/auto-1759419415.md
+++ b/.changeset/auto-1759419415.md
@@ -1,6 +1,0 @@
----
-"@club-employes/utopia": minor
----
-
-Updates from branch version/v4.20.0:
-- Design system components updated

--- a/.changeset/auto-1759481130.md
+++ b/.changeset/auto-1759481130.md
@@ -1,6 +1,0 @@
----
-"@club-employes/utopia": minor
----
-
-Updates from branch fix/workflow-changeset-trigger:
-- Design system components updated

--- a/.changeset/auto-1759481301.md
+++ b/.changeset/auto-1759481301.md
@@ -2,5 +2,5 @@
 "@club-employes/utopia": minor
 ---
 
-Updates from branch fix/workflow-changeset-trigger:
+Updates from branch version/v4.21.0:
 - Design system components updated

--- a/packages/utopia/CHANGELOG.md
+++ b/packages/utopia/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @club-employes/utopia
 
+## 4.21.0
+
+### Minor Changes
+
+- 8508a95: Updates from branch fix/workflow-changeset-trigger:
+  - Design system components updated
+- 8508a95: Updates from branch fix/workflow-changeset-trigger:
+  - Design system components updated
+- 24f8199: Updates from branch version/v4.20.0:
+  - Design system components updated
+- 8508a95: Updates from branch fix/workflow-changeset-trigger:
+  - Design system components updated
+
 ## 4.20.0
 
 ### Minor Changes

--- a/packages/utopia/package.json
+++ b/packages/utopia/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@club-employes/utopia",
   "description": "🎨 Modern Vue 3 design system with multi-brand theming, design tokens, and 30+ components. Supports Club Employés & Gifteo brands with light/dark modes.",
-  "version": "4.20.0",
+  "version": "4.21.0",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",


### PR DESCRIPTION
Automated version bump to v4.21.0

  **Changes:**
  - Version bumped to 4.21.0
  - Changesets consumed
  - Ready to publish to NPM

  This PR will be auto-merged and published to NPM.